### PR TITLE
Add alpha price precompile

### DIFF
--- a/precompiles/src/alpha.rs
+++ b/precompiles/src/alpha.rs
@@ -1,0 +1,33 @@
+use core::marker::PhantomData;
+
+use pallet_evm::PrecompileHandle;
+use precompile_utils::EvmResult;
+use sp_core::U256;
+use substrate_fixed::types::U96F32;
+
+use crate::PrecompileExt;
+
+pub struct AlphaPrecompile<R>(PhantomData<R>);
+
+impl<R> PrecompileExt<R::AccountId> for AlphaPrecompile<R>
+where
+    R: frame_system::Config + pallet_subtensor::Config,
+{
+    const INDEX: u64 = 2054;
+}
+
+#[precompile_utils::precompile]
+impl<R> AlphaPrecompile<R>
+where
+    R: frame_system::Config + pallet_subtensor::Config,
+{
+    #[precompile::public("getAlphaPrice(uint16)")]
+    #[precompile::view]
+    fn get_alpha_price(
+        _handle: &mut impl PrecompileHandle,
+        netuid: u16,
+    ) -> EvmResult<U256> {
+        let price: U96F32 = pallet_subtensor::Pallet::<R>::get_alpha_price(netuid);
+        Ok(U256::from(price.saturating_to_num::<u64>()))
+    }
+}

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -24,6 +24,7 @@ use crate::ed25519::*;
 use crate::extensions::*;
 use crate::metagraph::*;
 use crate::neuron::*;
+use crate::alpha::*;
 use crate::staking::*;
 use crate::subnet::*;
 
@@ -32,6 +33,7 @@ mod ed25519;
 mod extensions;
 mod metagraph;
 mod neuron;
+mod alpha;
 mod staking;
 mod subnet;
 
@@ -84,7 +86,7 @@ where
         Self(Default::default())
     }
 
-    pub fn used_addresses() -> [H160; 14] {
+    pub fn used_addresses() -> [H160; 15] {
         [
             hash(1),
             hash(2),
@@ -96,6 +98,7 @@ where
             hash(Ed25519Verify::<R::AccountId>::INDEX),
             hash(BalanceTransferPrecompile::<R>::INDEX),
             hash(StakingPrecompile::<R>::INDEX),
+            hash(AlphaPrecompile::<R>::INDEX),
             hash(SubnetPrecompile::<R>::INDEX),
             hash(MetagraphPrecompile::<R>::INDEX),
             hash(NeuronPrecompile::<R>::INDEX),
@@ -148,6 +151,9 @@ where
             }
             a if a == hash(StakingPrecompileV2::<R>::INDEX) => {
                 StakingPrecompileV2::<R>::try_execute::<R>(handle, PrecompileEnum::Staking)
+            }
+            a if a == hash(AlphaPrecompile::<R>::INDEX) => {
+                AlphaPrecompile::<R>::try_execute::<R>(handle, PrecompileEnum::Staking)
             }
             a if a == hash(SubnetPrecompile::<R>::INDEX) => {
                 SubnetPrecompile::<R>::try_execute::<R>(handle, PrecompileEnum::Subnet)

--- a/precompiles/src/solidity/alpha.abi
+++ b/precompiles/src/solidity/alpha.abi
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "netuid",
+        "type": "uint16"
+      }
+    ],
+    "name": "getAlphaPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/precompiles/src/solidity/alpha.sol
+++ b/precompiles/src/solidity/alpha.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.8.0;
+
+address constant IALPHA_ADDRESS = 0x0000000000000000000000000000000000000806;
+
+interface IAlpha {
+    /// @dev Returns the current alpha price for a subnet.
+    /// @param netuid The subnet identifier.
+    /// @return The alpha price in RAO per alpha.
+    function getAlphaPrice(uint16 netuid) external view returns (uint256);
+}

--- a/precompiles/src/solidity/stakingV2.abi
+++ b/precompiles/src/solidity/stakingV2.abi
@@ -251,5 +251,24 @@
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "netuid",
+        "type": "uint16"
+      }
+    ],
+    "name": "getAlphaPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -194,4 +194,12 @@ interface IStaking {
         bytes32 hotkey,
         uint256 netuid
     ) external view returns (uint256);
+
+    /**
+     * @dev Returns the current alpha price for a subnet.
+     *
+     * @param netuid The subnet identifier.
+     * @return The alpha price in RAO per alpha.
+     */
+    function getAlphaPrice(uint16 netuid) external view returns (uint256);
 }


### PR DESCRIPTION
## Summary
- expose `get_alpha_price` via new `AlphaPrecompile`
- register the precompile address
- expose the new function in `stakingV2.sol`
- update `stakingV2.abi`
- add Solidity interface/ABI for the new precompile

## Testing
- `cargo check --workspace --locked --offline` *(fails: could not download toolchain)*